### PR TITLE
Fixed example, typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ adapter][2] for your kinect.
 
 ## Usage
 
-Bifocals is available from clojars. Add `[bifocals 0.0.1]` to your project.clj
+Bifocals is available from clojars. Add `[bifocals "0.0.1"]` to your project.clj
 then `(:require [bifocals.core :as bifocals)` in your `ns` statement.
 
 There are some well-commented examples of using bifocals in the `examples`

--- a/examples/2D.clj
+++ b/examples/2D.clj
@@ -44,7 +44,7 @@
   ; You must call this in the draw function. Otherwise, your depth image will be
   ; all black, and user/skeleton tracking will not work.
   (bifocals/tick)
-  (image (bifocals/image) 0 0)
+  (image (bifocals/depth-image) 0 0)
   (no-stroke)
   (fill 0 255 0 128)
   ; The uids of the on-screen users are stored in a set at the


### PR DESCRIPTION
Fixed two small things that weren't correct. Added quotes around the version number in the dependency in the readme, and changed bifocals/image to bifocals/depth-image 
